### PR TITLE
fix: correctly expand the vue type definition

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -5,11 +5,11 @@ declare module '*.vue' {
   export default component
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $attrs: Record<string, unknown>
   }
-  
+
   interface ComponentInternalInstance {
     setupState: Record<string, any>
   }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,6 +22,6 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "types": ["vite/client", "node", "@vue/runtime-core"]
+    "types": ["vite/client", "node", "vue"]
   }
 }


### PR DESCRIPTION
According to [this document](https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties), change `declare module '@vue/runtime-core'` to `vue` to correctly set the extension type.